### PR TITLE
Remove redundant return statement

### DIFF
--- a/src/convertBindingsToObject.js
+++ b/src/convertBindingsToObject.js
@@ -1,43 +1,41 @@
 import _arrayFrom from './utils/arrayFrom';
 
 const convertBindingsToObject = (app) => {
-  if (!app.attributes['q-convert-bindings']) {
-    return;
-  }
+  if (app.attributes['q-convert-bindings']) {
+    const bindings = app.querySelectorAll('[q-binding]');
 
-  const bindings = app.querySelectorAll('[q-binding]');
+    return _arrayFrom(bindings).reduce((obj, binding) => {
+      const bindingValue = binding.attributes['q-binding'].value;
 
-  return _arrayFrom(bindings).reduce((obj, binding) => {
-    const bindingValue = binding.attributes['q-binding'].value;
+      if (bindingValue.indexOf(' as ') > 0) {
+        if (bindingValue.indexOf('[') > 0) {
+          const [ , name, index, dot, prop ] = /(\w+)\[(\d+)\](\.)?(.*)/.exec(bindingValue);
 
-    if (bindingValue.indexOf(' as ') > 0) {
-      if (bindingValue.indexOf('[') > 0) {
-        const [ , name, index, dot, prop ] = /(\w+)\[(\d+)\](\.)?(.*)/.exec(bindingValue);
+          obj[name] = obj[name] || [];
 
-        obj[name] = obj[name] || [];
+          if (dot) {
+            obj[name][index] = obj[name][index] || {};
 
-        if (dot) {
-          obj[name][index] = obj[name][index] || {};
-
-          obj[name][index][prop.split(' as ')[0]] = binding.textContent;
+            obj[name][index][prop.split(' as ')[0]] = binding.textContent;
+          }
+          else {
+            obj[name][index] = binding.textContent;
+          }
         }
         else {
-          obj[name][index] = binding.textContent;
+          const [ , name, prop ] = /(\w+)\.(\w+)\s.*/.exec(bindingValue);
+
+          obj[name] = obj[name] || {};
+          obj[name][prop] = binding.textContent;
         }
       }
-      else {
-        const [ , name, prop ] = /(\w+)\.(\w+)\s.*/.exec(bindingValue);
-
-        obj[name] = obj[name] || {};
-        obj[name][prop] = binding.textContent;
+      else if (binding.textContent) {
+        obj[bindingValue] = binding.textContent;
       }
-    }
-    else if (binding.textContent) {
-      obj[bindingValue] = binding.textContent;
-    }
 
-    return obj;
-  }, {});
+      return obj;
+    }, {});
+  }
 };
 
 export default convertBindingsToObject;


### PR DESCRIPTION
So at the moment you are testing if something is false then return (by default undefined). If you just wrap the lot and test the positive, then if its false, the function will be returned as undefined by default so you dont need to explicitly return anything as all functions return undefined by default if there is no return statement.