### PR TITLE
Handle html encoded values in comment bindings

### DIFF
--- a/src/convertBindingsToObject.js
+++ b/src/convertBindingsToObject.js
@@ -1,8 +1,7 @@
 import _arrayFrom from './utils/arrayFrom';
 
-var parseString = (str) => {
-  // unescape escaped characters
-  var decoded = (new DOMParser()).parseFromString(str, 'text/html').body.firstChild.textContent;
+const parseString = (str) => {
+  const decoded = (new DOMParser()).parseFromString(str, 'text/html').body.firstChild.textContent;
 
   try {
     return JSON.parse(decoded);

--- a/src/convertBindingsToObject.js
+++ b/src/convertBindingsToObject.js
@@ -1,7 +1,7 @@
 import _arrayFrom from './utils/arrayFrom';
 
 const parseString = (str) => {
-  const decoded = (new DOMParser()).parseFromString(str, 'text/html').body.firstChild.textContent;
+  const decoded = (new DOMParser()).parseFromString(str, 'text/html').body.textContent;
 
   try {
     return JSON.parse(decoded);

--- a/src/convertBindingsToObject.js
+++ b/src/convertBindingsToObject.js
@@ -1,7 +1,7 @@
 import _arrayFrom from './utils/arrayFrom';
 
 const parseString = (str) => {
-  const decoded = (new DOMParser()).parseFromString(str, 'text/html').body.firstChild.textContent;
+  const decoded = (new DOMParser()).parseFromString(str, 'text/html').body.firstChild;
 
   try {
     return JSON.parse(decoded);

--- a/src/convertBindingsToObject.js
+++ b/src/convertBindingsToObject.js
@@ -1,12 +1,13 @@
 import _arrayFrom from './utils/arrayFrom';
 
-var parseString = function parseString(str) {
+var parseString = (str) => {
   // unescape escaped characters
   var decoded = (new DOMParser()).parseFromString(str, 'text/html').body.firstChild.textContent;
 
   try {
     return JSON.parse(decoded);
-  } catch (e) {
+  }
+  catch (e) {
     return str;
   }
 };

--- a/src/convertBindingsToObject.js
+++ b/src/convertBindingsToObject.js
@@ -1,10 +1,12 @@
 import _arrayFrom from './utils/arrayFrom';
 
-const parseString = (str) => {
+var parseString = function parseString(str) {
+  // unescape escaped characters
+  var decoded = (new DOMParser()).parseFromString(str, 'text/html').body.firstChild.textContent;
+
   try {
-    return JSON.parse(str);
-  }
-  catch (e) {
+    return JSON.parse(decoded);
+  } catch (e) {
     return str;
   }
 };

--- a/src/convertBindingsToObject.js
+++ b/src/convertBindingsToObject.js
@@ -1,7 +1,7 @@
 import _arrayFrom from './utils/arrayFrom';
 
 const parseString = (str) => {
-  const decoded = (new DOMParser()).parseFromString(str, 'text/html').body.firstChild;
+  const decoded = (new DOMParser()).parseFromString(str, 'text/html').body.firstChild.textContent;
 
   try {
     return JSON.parse(decoded);


### PR DESCRIPTION
Passing unencoded values in comments allows values such as `--><script>alert(1)</script><!--` to be passed through and these will be executed by the browser. To prevent this, the values need to be html encoded, eg into `"--&gt;&lt;script&gt;alert(1)&lt;/script&gt;&lt;!--`. Existing Quench won't decode these values.

This change uses the DOMParser to decode strings that include these escaped characters, so a comment binding like this works:
```
<!-- q-binding:fieldSpecs.fanEmail = {   &quot;name&quot;: &quot;fanEmail&quot;,   &quot;required&quot;: true,   &quot;type&quot;: &quot;email&quot;,   &quot;validationMessage&quot;: &quot;We really really need your email&quot; } -->
```